### PR TITLE
Add 'xwaylandvideobridge' to default skipped windows

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -27,7 +27,7 @@
       <default>false</default>
     </entry>
     <entry name="SkipWindows" type="string">
-      <default>lattedock, latte-dock, org.kde.spectacle, spectacle, org.kde.yakuake</default>
+      <default>lattedock, latte-dock, org.kde.spectacle, spectacle, org.kde.yakuake, xwaylandvideobridge</default>
     </entry>
   </group>
 

--- a/contents/ui/config.ui
+++ b/contents/ui/config.ui
@@ -175,7 +175,8 @@ Automatically moves maximized or fullscreen windows to temporary virtual desktop
 latte-dock,
 org.kde.spectacle,
 spectacle,
-org.kde.yakuake</string>
+org.kde.yakuake,
+xwaylandvideobridge</string>
         </property>
 
         <property name="placeholderText">


### PR DESCRIPTION
Prevents a new, seemingly empty desktop from being created on every login when XWayland Video Bridge is autostarted by Plasma.