### PR TITLE
feat: restore windows to unmanaged desktop rather than first one

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Imitates the way macOS handles maximized and full-screened windows.
 
 ### Core Features:
 * **Automatic Virtual Desktop Creation**: The script moves full-screened and/or (fully) maximized windows to a new virtual desktop.
-* **Desktop Restoration**: When a window is restored to regular state (not full-screened and not fully maximized), the script returns it to the prior regular desktop and removes the temporary virtual desktop.
+* **Desktop Restoration**: When a window is restored to regular state (not full-screened and not fully maximized), the script returns it to a regular desktop and removes the temporary virtual desktop.
 * **Main Desktop Focus**: New non-maximized windows opened while on a full-screen application's desktop are automatically moved to and opened on the main desktop.
 * **Dialog & Toolbar Support**: Related windows (dialogs, toolbars, etc.) are automatically moved to the same desktop as their parent window.
 * **Context Menu Safety**: Popup menus and context menus (e.g., Dolphin's right-click menu) stay on their current desktop to prevent KWin crashes.
@@ -17,8 +17,8 @@ Imitates the way macOS handles maximized and full-screened windows.
 ### Behavior Logic:
 1. When a window is maximized, a new virtual desktop is created after the current one, and the window is moved to it
 2. The new virtual desktop displays only that maximized window and its related dialogs/toolbars
-3. When a window is un-maximized, its virtual desktop is deleted and the window returns to the regular desktop before it
-4. When on a full-screen app, opening a new non-maximized app forces it to open on the prior regular desktop and switches to it
+3. When a window is un-maximized, its virtual desktop is deleted and the window returns to a regular desktop
+4. When on a full-screen app, opening a new non-maximized app forces it to open on a regular desktop and switches to it
 
 ### Preview:
 ![Macsimize6](https://github.com/Ubiquitine/MACsimize6/assets/3274951/354014b3-5ea0-49ff-b2a2-5aab27471845)

--- a/README.md
+++ b/README.md
@@ -8,18 +8,16 @@ Imitates the way macOS handles maximized and full-screened windows.
 
 ### Core Features:
 * **Automatic Virtual Desktop Creation**: The script moves full-screened and/or (fully) maximized windows to a new virtual desktop.
-* **Desktop Restoration**: When a window is restored to regular state (not full-screened and not fully maximized), the script returns it to the main desktop and removes the temporary virtual desktop.
-* **Main Desktop Focus**: New non-maximized windows opened while on a full-screen application's desktop are automatically moved to and opened on the main desktop.
+* **Desktop Restoration**: When a window is restored to regular state (not full-screened and not fully maximized), the script returns it to the prior regular desktop and removes the temporary virtual desktop.
 * **Dialog & Toolbar Support**: Related windows (dialogs, toolbars, etc.) are automatically moved to the same desktop as their parent window.
 * **Context Menu Safety**: Popup menus and context menus (e.g., Dolphin's right-click menu) stay on their current desktop to prevent KWin crashes.
 * **Skip List Support**: Applications in the skip list are exempt from all rules and can open freely on any desktop.
 
 ### Behavior Logic:
-1. Initial state has only one virtual desktop (main desktop)
-2. When a window is maximized, a new virtual desktop is created after all existing ones, and the window is moved to it
-3. The new virtual desktop displays only that maximized window and its related dialogs/toolbars
-4. When a window is un-maximized, its virtual desktop is deleted and the window returns to the main desktop
-5. When on a non-main desktop (full-screen app), opening a new non-maximized app forces it to open on the main desktop and switches to it
+1. When a window is maximized, a new virtual desktop is created after the current one, and the window is moved to it
+2. The new virtual desktop displays only that maximized window and its related dialogs/toolbars
+3. When a window is un-maximized, its virtual desktop is deleted and the window returns to the regular desktop before it
+4. When on a full-screen app, opening a new non-maximized app forces it to open on the prior regular desktop and switches to it
 
 ### Preview:
 ![Macsimize6](https://github.com/Ubiquitine/MACsimize6/assets/3274951/354014b3-5ea0-49ff-b2a2-5aab27471845)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Imitates the way macOS handles maximized and full-screened windows.
 ### Core Features:
 * **Automatic Virtual Desktop Creation**: The script moves full-screened and/or (fully) maximized windows to a new virtual desktop.
 * **Desktop Restoration**: When a window is restored to regular state (not full-screened and not fully maximized), the script returns it to a regular desktop and removes the temporary virtual desktop.
-* **Main Desktop Focus**: New non-maximized windows opened while on a full-screen application's desktop are automatically moved to and opened on the main desktop.
+* **Regular Desktop Support**: New non-maximized windows opened while on a full-screen application's desktop are automatically moved to and opened on a regular desktop.
 * **Dialog & Toolbar Support**: Related windows (dialogs, toolbars, etc.) are automatically moved to the same desktop as their parent window.
 * **Context Menu Safety**: Popup menus and context menus (e.g., Dolphin's right-click menu) stay on their current desktop to prevent KWin crashes.
 * **Skip List Support**: Applications in the skip list are exempt from all rules and can open freely on any desktop.
@@ -18,7 +18,7 @@ Imitates the way macOS handles maximized and full-screened windows.
 1. When a window is maximized, a new virtual desktop is created after the current one, and the window is moved to it
 2. The new virtual desktop displays only that maximized window and its related dialogs/toolbars
 3. When a window is un-maximized, its virtual desktop is deleted and the window returns to a regular desktop
-4. When on a full-screen app, opening a new non-maximized app forces it to open on a regular desktop and switches to it
+4. When on a full-screen app, opening a new non-maximized app forces it to open on a regular desktop and switches to that desktop
 
 ### Preview:
 ![Macsimize6](https://github.com/Ubiquitine/MACsimize6/assets/3274951/354014b3-5ea0-49ff-b2a2-5aab27471845)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Imitates the way macOS handles maximized and full-screened windows.
 ### Core Features:
 * **Automatic Virtual Desktop Creation**: The script moves full-screened and/or (fully) maximized windows to a new virtual desktop.
 * **Desktop Restoration**: When a window is restored to regular state (not full-screened and not fully maximized), the script returns it to the prior regular desktop and removes the temporary virtual desktop.
+* **Main Desktop Focus**: New non-maximized windows opened while on a full-screen application's desktop are automatically moved to and opened on the main desktop.
 * **Dialog & Toolbar Support**: Related windows (dialogs, toolbars, etc.) are automatically moved to the same desktop as their parent window.
 * **Context Menu Safety**: Popup menus and context menus (e.g., Dolphin's right-click menu) stay on their current desktop to prevent KWin crashes.
 * **Skip List Support**: Applications in the skip list are exempt from all rules and can open freely on any desktop.

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -650,9 +650,9 @@ function installWindowHandlers(window)
 function updatePanelVisibility()
 {
     let panelVisibility =
-    workspace.currentDesktop === workspace.desktops[0]
-        ? "none"
-        : "dodgewindows";
+    isManagedDesktop(workspace.currentDesktop)
+        ? "dodgewindows"
+        : "none";
 
     if (panelVisibility === lastPanelMode)
         return;

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -8,7 +8,7 @@ const moveToLast            = readConfig("moveToLast", false);
 const enableIfOnlyOne       = readConfig("enableIfOnlyOne", false);
 const enablePanelVisibility = readConfig("enablePanelVisibility", false);
 const exclusiveDesktops     = readConfig("exclusiveDesktops", true);
-const mainDesktop           = readConfig("mainDesktop", false);
+const restoreToFirstDesktop = readConfig("restoreToFirstDesktop", false);
 const debugMode             = readConfig("debugMode", false);
 
 var lastPanelMode = "";
@@ -194,7 +194,7 @@ function getWindowClass(window)
 
 function getUnmanagedDesktopNumber()
 {
-    if (!mainDesktop)
+    if (!restoreToFirstDesktop)
     {
         for (i = workspace.currentDesktop.x11DesktopNumber - 2; i >= 0; i--)
         {

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -191,6 +191,25 @@ function getWindowClass(window)
     return window.resourceClass.toString().toLowerCase();
 }
 
+function getPriorDesktopNumber()
+{
+    let managedDesktops = [];
+    for (let window of workspace.windowList())
+    {
+        const desktop = window.desktops[0];
+        if (isManagedDesktop(desktop))
+            managedDesktops.push(desktop.id);
+    }
+
+    for (i = workspace.currentDesktop.x11DesktopNumber - 2; i >= 0; i--)
+    {
+        if (!managedDesktops.includes(workspace.desktops[i].id))
+            return i;
+    }
+
+    return 0;
+}
+
 function getNextDesktopNumber()
 {
     for (let i = 0; i < workspace.desktops.length; ++i)
@@ -345,7 +364,7 @@ function restoreDesktop(window)
 
     const desktop = state.dedicatedDesktop;
 
-    logWindow(window, "Restoring to the main desktop.");
+    logWindow(window, "Restoring to the prior desktop.");
 
     try
     {
@@ -355,9 +374,9 @@ function restoreDesktop(window)
         //
         state.dedicatedDesktop = null;
 
-        window.desktops = [workspace.desktops[0]];
-
-        workspace.currentDesktop = workspace.desktops[0];
+        let newDesktop = workspace.desktops[getPriorDesktopNumber()];
+        window.desktops = [newDesktop];
+        workspace.currentDesktop = newDesktop;
 
         removeManagedDesktop(desktop);
     }
@@ -384,10 +403,10 @@ function cleanupClosedWindow(window)
 
     if (desktop)
     {
-        const mainDesktop = workspace.desktops[0];
+        const priorDesktop = workspace.desktops[getPriorDesktopNumber()];
 
-        if (mainDesktop && workspace.currentDesktop === desktop)
-            workspace.currentDesktop = mainDesktop;
+        if (priorDesktop && workspace.currentDesktop === desktop)
+            workspace.currentDesktop = priorDesktop;
 
         removeManagedDesktop(desktop);
     }
@@ -460,7 +479,7 @@ function evaluateWindow(window)
     }
 
     //
-    // Minimized windows are always restored to the main desktop.
+    // Minimized windows are always restored to the prior desktop.
     //
     if (window.minimized)
     {
@@ -708,21 +727,21 @@ function install()
 
         //
         // Move unrelated windows from the
-        // dedicated desktop to the main desktop.
+        // dedicated desktop to the prior desktop.
         //
-        const mainDesktop = workspace.desktops[0];
+        const priorDesktop = workspace.desktops[getPriorDesktopNumber()];
 
-        if (workspace.currentDesktop !== mainDesktop &&
+        if (workspace.currentDesktop !== priorDesktop &&
             isManagedDesktop(workspace.currentDesktop) &&
             !sameClassDesktop(window) &&
             exclusiveDesktops)
         {
             logWindow(window,
-                "Moving unrelated window to main desktop.");
+                "Moving unrelated window to prior desktop.");
 
-            window.desktops = [mainDesktop];
+            window.desktops = [priorDesktop];
 
-            workspace.currentDesktop = mainDesktop;
+            workspace.currentDesktop = priorDesktop;
         }
 
         // installWindowHandlers can reject windows that should not be

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -193,17 +193,9 @@ function getWindowClass(window)
 
 function getPriorDesktopNumber()
 {
-    let managedDesktops = [];
-    for (let window of workspace.windowList())
-    {
-        const desktop = window.desktops[0];
-        if (isManagedDesktop(desktop))
-            managedDesktops.push(desktop.id);
-    }
-
     for (i = workspace.currentDesktop.x11DesktopNumber - 2; i >= 0; i--)
     {
-        if (!managedDesktops.includes(workspace.desktops[i].id))
+        if (!isManagedDesktop(workspace.desktops[i]))
             return i;
     }
 

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -192,7 +192,7 @@ function getWindowClass(window)
     return window.resourceClass.toString().toLowerCase();
 }
 
-function getPriorDesktopNumber()
+function getUnmanagedDesktopNumber()
 {
     if (!mainDesktop)
     {
@@ -360,7 +360,7 @@ function restoreDesktop(window)
 
     const desktop = state.dedicatedDesktop;
 
-    logWindow(window, "Restoring to the prior desktop.");
+    logWindow(window, "Restoring to unmanaged desktop.");
 
     try
     {
@@ -370,7 +370,7 @@ function restoreDesktop(window)
         //
         state.dedicatedDesktop = null;
 
-        let newDesktop = workspace.desktops[getPriorDesktopNumber()];
+        let newDesktop = workspace.desktops[getUnmanagedDesktopNumber()];
         window.desktops = [newDesktop];
         workspace.currentDesktop = newDesktop;
 
@@ -399,10 +399,10 @@ function cleanupClosedWindow(window)
 
     if (desktop)
     {
-        const priorDesktop = workspace.desktops[getPriorDesktopNumber()];
+        const newDesktop = workspace.desktops[getUnmanagedDesktopNumber()];
 
-        if (priorDesktop && workspace.currentDesktop === desktop)
-            workspace.currentDesktop = priorDesktop;
+        if (newDesktop && workspace.currentDesktop === newDesktop)
+            workspace.currentDesktop = newDesktop;
 
         removeManagedDesktop(desktop);
     }
@@ -475,7 +475,7 @@ function evaluateWindow(window)
     }
 
     //
-    // Minimized windows are always restored to the prior desktop.
+    // Minimized windows are always restored to an unmanaged desktop.
     //
     if (window.minimized)
     {
@@ -723,21 +723,21 @@ function install()
 
         //
         // Move unrelated windows from the
-        // dedicated desktop to the prior desktop.
+        // dedicated desktop to an unmanaged desktop.
         //
-        const priorDesktop = workspace.desktops[getPriorDesktopNumber()];
+        const newDesktop = workspace.desktops[getUnmanagedDesktopNumber()];
 
-        if (workspace.currentDesktop !== priorDesktop &&
+        if (workspace.currentDesktop !== newDesktop &&
             isManagedDesktop(workspace.currentDesktop) &&
             !sameClassDesktop(window) &&
             exclusiveDesktops)
         {
             logWindow(window,
-                "Moving unrelated window to prior desktop.");
+                "Moving unrelated window to unmanaged desktop.");
 
-            window.desktops = [priorDesktop];
+            window.desktops = [newDesktop];
 
-            workspace.currentDesktop = priorDesktop;
+            workspace.currentDesktop = newDesktop;
         }
 
         // installWindowHandlers can reject windows that should not be

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -370,9 +370,8 @@ function restoreDesktop(window)
         //
         state.dedicatedDesktop = null;
 
-        let newDesktop = workspace.desktops[getUnmanagedDesktopNumber()];
-        window.desktops = [newDesktop];
-        workspace.currentDesktop = newDesktop;
+        workspace.currentDesktop = workspace.desktops[getUnmanagedDesktopNumber()];
+        window.desktops = [workspace.currentDesktop];
 
         removeManagedDesktop(desktop);
     }
@@ -399,10 +398,8 @@ function cleanupClosedWindow(window)
 
     if (desktop)
     {
-        const newDesktop = workspace.desktops[getUnmanagedDesktopNumber()];
-
-        if (newDesktop && workspace.currentDesktop === desktop)
-            workspace.currentDesktop = newDesktop;
+        if (workspace.currentDesktop === desktop)
+            workspace.currentDesktop = workspace.desktops[getUnmanagedDesktopNumber()];
 
         removeManagedDesktop(desktop);
     }

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -8,6 +8,7 @@ const moveToLast            = readConfig("moveToLast", false);
 const enableIfOnlyOne       = readConfig("enableIfOnlyOne", false);
 const enablePanelVisibility = readConfig("enablePanelVisibility", false);
 const exclusiveDesktops     = readConfig("exclusiveDesktops", true);
+const mainDesktop           = readConfig("mainDesktop", false);
 const debugMode             = readConfig("debugMode", false);
 
 var lastPanelMode = "";
@@ -193,10 +194,13 @@ function getWindowClass(window)
 
 function getPriorDesktopNumber()
 {
-    for (i = workspace.currentDesktop.x11DesktopNumber - 2; i >= 0; i--)
+    if (!mainDesktop)
     {
-        if (!isManagedDesktop(workspace.desktops[i]))
-            return i;
+        for (i = workspace.currentDesktop.x11DesktopNumber - 2; i >= 0; i--)
+        {
+            if (!isManagedDesktop(workspace.desktops[i]))
+                return i;
+        }
     }
 
     return 0;

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -401,7 +401,7 @@ function cleanupClosedWindow(window)
     {
         const newDesktop = workspace.desktops[getUnmanagedDesktopNumber()];
 
-        if (newDesktop && workspace.currentDesktop === newDesktop)
+        if (newDesktop && workspace.currentDesktop === desktop)
             workspace.currentDesktop = newDesktop;
 
         removeManagedDesktop(desktop);

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -23,6 +23,9 @@
     <entry name="exclusiveDesktops" type="bool">
       <default>true</default>
     </entry>
+    <entry name="mainDesktop" type="bool">
+      <default>false</default>
+    </entry>
     <entry name="debugMode" type="bool">
       <default>false</default>
     </entry>

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -23,7 +23,7 @@
     <entry name="exclusiveDesktops" type="bool">
       <default>true</default>
     </entry>
-    <entry name="mainDesktop" type="bool">
+    <entry name="restoreToFirstDesktop" type="bool">
       <default>false</default>
     </entry>
     <entry name="debugMode" type="bool">

--- a/contents/ui/config.ui
+++ b/contents/ui/config.ui
@@ -119,6 +119,17 @@ Automatically moves maximized or fullscreen windows to temporary virtual desktop
       </item>
 
       <item>
+       <widget class="QCheckBox" name="kcfg_mainDesktop">
+        <property name="text">
+         <string>Treat first desktop as main desktop</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+
+      <item>
        <widget class="QCheckBox" name="kcfg_enableIfOnlyOne">
         <property name="text">
          <string>Only enable on single-monitor systems</string>

--- a/contents/ui/config.ui
+++ b/contents/ui/config.ui
@@ -119,9 +119,9 @@ Automatically moves maximized or fullscreen windows to temporary virtual desktop
       </item>
 
       <item>
-       <widget class="QCheckBox" name="kcfg_mainDesktop">
+       <widget class="QCheckBox" name="kcfg_restoreToFirstDesktop">
         <property name="text">
-         <string>Treat first desktop as main desktop</string>
+         <string>Always restore windows to the first desktop</string>
         </property>
         <property name="checked">
          <bool>false</bool>


### PR DESCRIPTION
This makes it so that when you un-maximize a window it puts it on the next unmanged desktop to the left rather than the first one. Managed windows are skipped over when finding the desktop to put it on.

New windows are also created directly to the left of the managed window(s) instead of the first one now in exclusive mode.

If you'd like I could put this behind a config option, it would just need to force `getPriorDesktopNumber()` to return 0 rather than actually running its logic.

---

I accidentally messed up the branch while rebasing #33, sorry!