### PR TITLE
feat: smooth the maximizing animation using all desktops mode

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -9,18 +9,16 @@ const enableIfOnlyOne       = readConfig("enableIfOnlyOne", false);
 const enablePanelVisibility = readConfig("enablePanelVisibility", false);
 const exclusiveDesktops     = readConfig("exclusiveDesktops", true);
 const useAbsoluteEnds      = readConfig("useAbsoluteEnds", false);
+const smoothAnimationTime   = readConfig("smoothAnimationTime", 700);
 const debugMode             = readConfig("debugMode", false);
 
-var lastPanelMode = "";
-var panelTimer = new QTimer();
 
-panelTimer.interval = 50;
+//
+// Globals
+//
 
-panelTimer.timeout.connect(function() {
-    // Stop the timer before updating panels visibility
-    panelTimer.stop();
-    updatePanelVisibility();
-});
+let lastPanelMode = "";
+let panelVisibilityLock = false;
 
 //
 // Constants
@@ -279,6 +277,22 @@ function shouldSkip(window)
     return false;
 }
 
+function delayedCall(delay, fn)
+{
+    if (delay)
+    {
+        let timer = new QTimer();
+        timer.interval = delay;
+        timer.singleShot = true;
+        timer.timeout.connect(fn);
+        timer.start();
+    }
+    else
+    {
+        fn();
+    }
+}
+
 //
 // Desktop management
 //
@@ -317,6 +331,32 @@ function removeManagedDesktop(desktop)
     workspace.removeDesktop(desktop);
 }
 
+function moveToDesktop(window, newDesktop, oldDesktop) {
+    // Changing panel visibility interrupts the maximize
+    // animation, but the un-maximize animation is fine.
+    panelVisibilityLock = !oldDesktop;
+
+    if (smoothAnimationTime)
+        window.onAllDesktops = true;
+
+    workspace.currentDesktop = newDesktop;
+
+    delayedCall(smoothAnimationTime, function() {
+
+        window.onAllDesktops = false;
+        window.desktops = [newDesktop];
+
+        panelVisibilityLock = false;
+
+        if (enablePanelVisibility)
+            updatePanelVisibility();
+
+        if (oldDesktop)
+            removeManagedDesktop(oldDesktop);
+
+    });
+}
+
 function moveToNewDesktop(window)
 {
     if (enableIfOnlyOne &&
@@ -347,8 +387,7 @@ function moveToNewDesktop(window)
 
         state.dedicatedDesktop = desktop;
 
-        window.desktops = [desktop];
-        workspace.currentDesktop = desktop;
+        moveToDesktop(window, desktop);
     }
     finally
     {
@@ -369,7 +408,7 @@ function restoreDesktop(window)
     if (!beginDesktopTransition(state))
         return;
 
-    const desktop = state.dedicatedDesktop;
+    const currentDesktop = state.dedicatedDesktop;
 
     logWindow(window, "Restoring to unmanaged desktop.");
 
@@ -381,10 +420,7 @@ function restoreDesktop(window)
         //
         state.dedicatedDesktop = null;
 
-        workspace.currentDesktop = workspace.desktops[getUnmanagedDesktopNumber()];
-        window.desktops = [workspace.currentDesktop];
-
-        removeManagedDesktop(desktop);
+        moveToDesktop(window, workspace.desktops[getUnmanagedDesktopNumber()], currentDesktop);
     }
     finally
     {
@@ -657,6 +693,9 @@ function installWindowHandlers(window)
 
 function updatePanelVisibility()
 {
+    if (panelVisibilityLock)
+        return;
+
     let panelVisibility =
     isManagedDesktop(workspace.currentDesktop)
         ? "dodgewindows"
@@ -781,8 +820,7 @@ function install()
     {
        workspace.currentDesktopChanged.connect(function() {
 
-            panelTimer.stop();
-            panelTimer.start();
+            updatePanelVisibility();
 
         });
     }

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -29,6 +29,9 @@
     <entry name="debugMode" type="bool">
       <default>false</default>
     </entry>
+    <entry name="smoothAnimationTime" type="int">
+      <default>700</default>
+    </entry>
     <entry name="SkipWindows" type="string">
       <default>lattedock, latte-dock, org.kde.spectacle, spectacle, org.kde.yakuake, xwaylandvideobridge</default>
     </entry>

--- a/contents/ui/config.ui
+++ b/contents/ui/config.ui
@@ -150,6 +150,44 @@ will be created after the very last desktop.</string>
 
 
    <!-- ====================================================== -->
+   <!-- Animation -->
+   <!-- ====================================================== -->
+
+   <item>
+    <widget class="QGroupBox" name="groupPanels">
+     <property name="title">
+      <string>Animation</string>
+     </property>
+
+     <layout class="QVBoxLayout">
+
+      <item>
+       <widget class="QLabel" name="SmoothAnimationTime">
+        <property name="text">
+         <string>Smoothing animation time: (default 700ms, set to 0 to disable)</string>
+        </property>
+       </widget>
+      </item>
+
+      <item>
+       <widget class="QLineEdit" name="kcfg_smoothAnimationTime">
+        <property name="text">
+         <string>700</string>
+        </property>
+        <property name="placeholderText">
+         <string>time in miliseconds, 0 to disable</string>
+        </property>
+        <property name="clearButtonEnabled">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+
+     </layout>
+    </widget>
+   </item>
+
+   <!-- ====================================================== -->
    <!-- Panels -->
    <!-- ====================================================== -->
 


### PR DESCRIPTION
This makes the (un)maximizing much more fluid by utilizing all-desktops mode to lock the window in place during the transition.

It's not always 100% perfect looking so you can still revert fully to the old behaviour by setting the animation time to `0`, with any other value it adjusts for if you use faster or slower animations since as far as I could tell there's no direct hook for the end of an animation. (if its too low there will be a jolt as conflicts make animations cut short, if its too high you're more likely to notice the minor visual side effects of allowing these animations to play nice if you quickly do something to cut it off)

Despite that I'm still mostly happy with how it is, unless you quickly max -> unmax or switch immediately after maximizing it looks much nicer than before imo, and you can always disable this if it doesn't play nice with your animations setup.

[画面録画_20260803_194325.webm](https://github.com/user-attachments/assets/ce192b90-0169-45e2-b4b1-736972b87195)

---

Oh yeah, I also removed the timer on the panel visibility cause as far as I can tell it wasn't doing anything. If there's reason to keep that 50ms delay, it can be easily re-added using the new delayedCall() function since that was just a oneshot done manually. 