### PR TITLE
fix: make moveToLast setting work on contiguous blocks

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -8,7 +8,7 @@ const moveToLast            = readConfig("moveToLast", false);
 const enableIfOnlyOne       = readConfig("enableIfOnlyOne", false);
 const enablePanelVisibility = readConfig("enablePanelVisibility", false);
 const exclusiveDesktops     = readConfig("exclusiveDesktops", true);
-const restoreToFirstDesktop = readConfig("restoreToFirstDesktop", false);
+const useAbsoluteEnds      = readConfig("useAbsoluteEnds", false);
 const debugMode             = readConfig("debugMode", false);
 
 var lastPanelMode = "";
@@ -194,7 +194,7 @@ function getWindowClass(window)
 
 function getUnmanagedDesktopNumber()
 {
-    if (!restoreToFirstDesktop)
+    if (!useAbsoluteEnds)
     {
         for (i = workspace.currentDesktop.x11DesktopNumber - 2; i >= 0; i--)
         {
@@ -210,7 +210,7 @@ function getNextDesktopNumber()
 {
     if (moveToLast)
     {
-        if (!restoreToFirstDesktop)
+        if (!useAbsoluteEnds)
         {
             // Try to find the end of the current block of managed desktops
             for (let i = workspace.currentDesktop.x11DesktopNumber; i < workspace.desktops.length; ++i)

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -208,13 +208,26 @@ function getUnmanagedDesktopNumber()
 
 function getNextDesktopNumber()
 {
-    for (let i = 0; i < workspace.desktops.length; ++i)
+    if (moveToLast)
     {
-        if (workspace.desktops[i] === workspace.currentDesktop)
-            return i + 1;
-    }
+        if (!restoreToFirstDesktop)
+        {
+            // Try to find the end of the current block of managed desktops
+            for (let i = workspace.currentDesktop.x11DesktopNumber; i < workspace.desktops.length; ++i)
+            {
+                if (!isManagedDesktop(workspace.desktops[i]))
+                    return i;
+            }
+        }
 
-    return workspace.desktops.length;
+        return workspace.desktops.length;
+    }
+    else
+    {
+        // The X11 Desktop Number is 1-indexed, the return value
+        // is 0-indexed, so one is already added.
+        return workspace.currentDesktop.x11DesktopNumber;
+    }
 }
 
 //
@@ -289,9 +302,7 @@ function isManagedDesktop(desktop)
 
 function createManagedDesktop(window)
 {
-    const index = moveToLast
-        ? workspace.desktops.length
-        : getNextDesktopNumber();
+    const index = getNextDesktopNumber();
 
     workspace.createDesktop(index, window.caption.toString());
 

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -23,7 +23,7 @@
     <entry name="exclusiveDesktops" type="bool">
       <default>true</default>
     </entry>
-    <entry name="restoreToFirstDesktop" type="bool">
+    <entry name="useAbsoluteEnds" type="bool">
       <default>false</default>
     </entry>
     <entry name="debugMode" type="bool">

--- a/contents/ui/config.ui
+++ b/contents/ui/config.ui
@@ -90,6 +90,24 @@ Automatically moves maximized or fullscreen windows to temporary virtual desktop
        </widget>
       </item>
 
+      <item>
+       <widget class="QCheckBox" name="kcfg_useAbsoluteEnds">
+        <property name="text">
+         <string>Use absolute first and last desktops</string>
+        </property>
+        <property name="toolTip">
+         <string>When enabled, windows will always be restored to
+the very first desktop.
+
+If paired with creating desktops at the end, they
+will be created after the very last desktop.</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+
      </layout>
     </widget>
    </item>
@@ -114,17 +132,6 @@ Automatically moves maximized or fullscreen windows to temporary virtual desktop
         </property>
         <property name="checked">
          <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-
-      <item>
-       <widget class="QCheckBox" name="kcfg_restoreToFirstDesktop">
-        <property name="text">
-         <string>Always restore windows to the first desktop</string>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
I started fiddling with all the combinations of settings to try replicate your crash in #37 and didn't manage to crash it, but I did notice what I think is rather unintuitive behaviour on the move to last setting that I'd missed.

This makes it so that:
- restoreToFirstDesktop => useAbsoluteEnds
- moveToLast + useAbsoluteEnds = exactly the old behaviour
- moveToLast + !useAbsoluteEnds = place the new desktop at the end of a contiguous block of dedicated desktops after it, if any
- !moveToLast = also simplified, returns the x11DesktopNumber instead of looping it

I figured that seemed logical